### PR TITLE
Add `order` to dataset

### DIFF
--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -11,6 +11,7 @@ class Dataset {
     this.quotedName = db.escapeId(name);
     this.conn = conn;
     this.criteria = null;
+    this.sortings = [];
   }
 
   /** TODO: write doc comment */
@@ -19,6 +20,7 @@ class Dataset {
 
     let sql = `SELECT * FROM ${this.quotedName}`;
     sql += this.whereSql(conditions);
+    sql += this.orderSql;
 
     return await db.selectRows(sql, this.conn);
   }
@@ -53,6 +55,7 @@ class Dataset {
     let sql = `DELETE FROM ${this.quotedName}`;
 
     sql += this.whereSql(conditions);
+    sql += this.orderSql;
 
     return await db.executeAndAffected(sql, this.conn);
   }
@@ -62,6 +65,7 @@ class Dataset {
     let sql = `SELECT * FROM ${this.quotedName}`;
 
     sql += this.whereSql(conditions);
+    sql += this.orderSql;
     sql += ' LIMIT 1';
 
     return await db.selectRow(sql, this.conn);
@@ -72,6 +76,7 @@ class Dataset {
     let sql = `SELECT ${db.escapeId(column)} FROM ${this.quotedName}`;
 
     sql += this.whereSql(conditions);
+    sql += this.orderSql;
 
     return await db.pluck(sql, this.conn);
   }
@@ -81,6 +86,7 @@ class Dataset {
     let sql = `UPDATE ${this.quotedName} SET ${db.assignments(assignments)}`;
 
     sql += this.whereSql(conditions);
+    sql += this.orderSql;
 
     return await db.executeAndAffected(sql, this.conn);
   }
@@ -111,6 +117,7 @@ class Dataset {
 
     Object.assign(copy, {
       criteria: this.criteria,
+      sortings: this.sortings,
       ...changes
     });
 
@@ -118,8 +125,22 @@ class Dataset {
   }
 
   /** TODO: write doc comment */
+  order(...cols) {
+    return this.clone({ sortings: [...this.sortings, ...cols] });
+  }
+
+  /** TODO: write doc comment */
   where(criteria) {
     return this.clone({ criteria: this.restrictCriteria(criteria) });
+  }
+
+  /** @private */
+  get orderSql() {
+    // FIXME: sanitize input
+    // TODO: memoize
+    if (this.sortings.length) return ` ORDER BY ${this.sortings.join(', ')}`;
+
+    return '';
   }
 
   /** @private */

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -18,10 +18,7 @@ class Dataset {
     // TODO: add support for string conditions
 
     let sql = `SELECT * FROM ${this.quotedName}`;
-
-    conditions = this.restrictCriteria(conditions);
-    if (isPresent(conditions))
-      sql += ` WHERE ${db.conditions(conditions)}`;
+    sql += this.whereSql(conditions);
 
     return await db.selectRows(sql, this.conn);
   }
@@ -55,9 +52,7 @@ class Dataset {
   async delete(conditions) {
     let sql = `DELETE FROM ${this.quotedName}`;
 
-    conditions = this.restrictCriteria(conditions);
-    if (isPresent(conditions))
-      sql += ` WHERE ${db.conditions(conditions)}`;
+    sql += this.whereSql(conditions);
 
     return await db.executeAndAffected(sql, this.conn);
   }
@@ -66,10 +61,7 @@ class Dataset {
   async get(conditions) {
     let sql = `SELECT * FROM ${this.quotedName}`;
 
-    conditions = this.restrictCriteria(conditions);
-    if (isPresent(conditions))
-      sql += ` WHERE ${db.conditions(conditions)}`;
-
+    sql += this.whereSql(conditions);
     sql += ' LIMIT 1';
 
     return await db.selectRow(sql, this.conn);
@@ -79,9 +71,7 @@ class Dataset {
   async pluck(column, conditions) {
     let sql = `SELECT ${db.escapeId(column)} FROM ${this.quotedName}`;
 
-    conditions = this.restrictCriteria(conditions);
-    if (isPresent(conditions))
-      sql += ` WHERE ${db.conditions(conditions)}`;
+    sql += this.whereSql(conditions);
 
     return await db.pluck(sql, this.conn);
   }
@@ -90,9 +80,7 @@ class Dataset {
   async update(assignments, conditions) {
     let sql = `UPDATE ${this.quotedName} SET ${db.assignments(assignments)}`;
 
-    conditions = this.restrictCriteria(conditions);
-    if (isPresent(conditions))
-      sql += ` WHERE ${db.conditions(conditions)}`;
+    sql += this.whereSql(conditions);
 
     return await db.executeAndAffected(sql, this.conn);
   }
@@ -123,6 +111,15 @@ class Dataset {
     copy.criteria = this.restrictCriteria(criteria);
 
     return copy;
+  }
+
+  /** @private */
+  whereSql(conditions) {
+    conditions = this.restrictCriteria(conditions);
+
+    if (isPresent(conditions)) return ` WHERE ${db.conditions(conditions)}`;
+
+    return '';
   }
 }
 

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -105,12 +105,21 @@ class Dataset {
     return `(${existing}) AND (${additional})`;
   }
 
-  /** TODO: write doc comment */
-  where(criteria) {
+  /** @private */
+  clone(changes = {}) {
     const copy = new this.constructor(this.tableName, this.conn);
-    copy.criteria = this.restrictCriteria(criteria);
+
+    Object.assign(copy, {
+      criteria: this.criteria,
+      ...changes
+    });
 
     return copy;
+  }
+
+  /** TODO: write doc comment */
+  where(criteria) {
+    return this.clone({ criteria: this.restrictCriteria(criteria) });
   }
 
   /** @private */


### PR DESCRIPTION
Добавляет возможность указания порядка сортировки на `dataset`

Пример:

```js
// SELECT * FROM table ORDER BY price DESC, rating
await db.dataset('table').order('price DESC', 'rating').all(); 
```