### PR TITLE
Add support for Javascript migrations

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -8,6 +8,11 @@ const path = require('path');
 
 module.exports = migrator;
 
+const RUNNERS = {
+  '.js': applyJSMigration,
+  '.sql': applySQLMigration
+};
+
 const migrationsLog = db.escapeId('schema_migrations');
 
 /** TODO: add doc comment */
@@ -51,7 +56,7 @@ async function loadAvailableMigrations(migrationsPath) {
     return {
       name: basename,
       path: fullPath,
-      runner: (extname === '.sql') && applySQLMigration
+      runner: RUNNERS[extname]
     }
   }
 }
@@ -72,6 +77,12 @@ async function recordMigrationApplied({ name }) {
   await db.execute(`
     INSERT INTO ${migrationsLog} VALUES (${quotedName})
   `);
+}
+
+async function applyJSMigration({ name, path: fullPath }) {
+  const migration = require(fullPath);
+
+  await migration(db);
 }
 
 async function applySQLMigration({ path: fullPath }) {

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -1,7 +1,10 @@
 // FIXME: running migrations requires multiple statements flag being set
 //
 // TODO: destructure used methods from adapter into local consts
-const db = require('./adapter');
+const db = {
+  ...require('./adapter'),
+  dataset: require('./dataset')
+}
 
 const fs = require('fs/promises');
 const path = require('path');

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -37,35 +37,45 @@ async function loadAppliedMigrations() {
   `);
 }
 
-const isMigrationExt = name => path.extname(name).toLowerCase() === '.sql';
-
 async function loadAvailableMigrations(migrationsPath) {
   const files = await fs.readdir(migrationsPath);
 
   return files.
-    filter(isMigrationExt).
-    map(name => ({
-      name,
-      path: path.join(migrationsPath, name)
-  }));
+    map(makeMigrationObject).
+    filter(({ runner }) => runner);
+
+  function makeMigrationObject(basename) {
+    const extname = path.extname(basename).toLowerCase();
+    const fullPath = path.join(migrationsPath, basename);
+
+    return {
+      name: basename,
+      path: fullPath,
+      runner: (extname === '.sql') && applySQLMigration
+    }
+  }
 }
 
-async function applyMigration({ name, path: fullPath }) {
+async function applyMigration(migration) {
+  await migration.runner(migration);
+  await recordMigrationApplied(migration);
+}
+
+async function recordMigrationApplied({ name }) {
+  const quotedName = db.escape(name);
+
+  await db.execute(`
+    INSERT INTO ${migrationsLog} VALUES (${quotedName})
+  `);
+}
+
+async function applySQLMigration({ path: fullPath }) {
   const contents = await fs.readFile(fullPath, { encoding: 'utf-8' });
 
   // You should enable multipleStatements option in order to support
   // migrations that require more than one query
   // TODO: add support for JS migrations
   await db.execute(contents);
-  await recordMigrationApplied(name);
-
-  async function recordMigrationApplied(name) {
-    const quotedName = db.escape(name);
-
-    await db.execute(`
-      INSERT INTO ${migrationsLog} VALUES (${quotedName})
-    `);
-  }
 }
 
 /** @private */

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -57,7 +57,12 @@ async function loadAvailableMigrations(migrationsPath) {
 }
 
 async function applyMigration(migration) {
-  await migration.runner(migration);
+  try {
+    await migration.runner(migration);
+  } catch (err) {
+    console.error(migration.name + ':\n\t', err);
+    throw err;
+  }
   await recordMigrationApplied(migration);
 }
 


### PR DESCRIPTION
Javascript migration should be a JS script in migrations folder that exports a single function to perform the migration.

This function will be passed a database adapter instance as an argument