### PR TITLE
Allow disjunctive criteria

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -141,7 +141,11 @@ function assignments(changes) {
 
 /** TODO: write doc comment */
 function conditions(criteria) {
-  if (typeof criteria === 'string') return criteria;
+  if (typeof criteria === 'string') {
+    return criteria;
+  } else if (Array.isArray(criteria)) {
+    return `(${criteria.map(conditions).join(') OR (')})`;
+  }
 
   // XXX: no support for multiple alternatives at top level criteria yet
   const terms = [];


### PR DESCRIPTION
`condition([{ a: '1' }, { b: 2 }])` now can be used to express the SQL
equivalent of (a = '1') OR (b = 2)