### PR TITLE
Add debug output

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1,8 +1,11 @@
 const mysql = require('mysql2/promise');
+const logger = require('debug');
 
 const { env } = require('@snooty/utils');
 
 const { escape, escapeId } = mysql;
+
+const debug = logger('db:sql');
 
 module.exports = {
   assignments,
@@ -38,6 +41,9 @@ async function execute(query, conn) {
     instantiatePool();
     conn = pool;
   }
+
+  const logger = conn.logger || debug;
+  logger(query);
 
   return await conn.query(query);
 }
@@ -96,6 +102,7 @@ async function transaction(perform) {
   instantiatePool();
 
   const conn = await pool.getConnection();
+  conn.logger = logger.bind(null, `tx@${conn.connectionId}`);
   const handle = wrap(conn);
 
   try {
@@ -109,6 +116,7 @@ async function transaction(perform) {
 
     throw e;
   } finally {
+    delete conn.logger;
     conn.release();
   }
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -102,7 +102,7 @@ async function transaction(perform) {
   instantiatePool();
 
   const conn = await pool.getConnection();
-  conn.logger = logger.bind(null, `tx@${conn.connectionId}`);
+  conn.logger = debug.extend(`:tx@${conn.connection.connectionId}`);
   const handle = wrap(conn);
 
   try {

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -20,7 +20,8 @@ class Dataset {
 
     this.logger = logger(`db:dataset:${name}`);
     if (conn) // we're in transaction
-      this.logger = this.logger.bind(this, `tx@${conn.connectionId}`);
+      this.logger =
+        this.logger.extend(`tx@${conn.connection.connectionId}`);
   }
 
   /** TODO: write doc comment */
@@ -62,7 +63,7 @@ class Dataset {
     // that does not match the filters
     if (id) record = await this.get({ id });
 
-    debug(`-> ${record}`);
+    debug('-> %O', record);
 
     return record;
   }

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -1,5 +1,6 @@
 // TODO: destructure used methods from adapter into local consts
 const db = require('./adapter');
+const logger = require('debug');
 
 module.exports = dataset;
 
@@ -16,6 +17,10 @@ class Dataset {
     this.criteria = null;
     this.sortings = [];
     this.selection = '*';
+
+    this.logger = logger(`db:dataset:${name}`);
+    if (conn) // we're in transaction
+      this.logger = this.logger.bind(this, `tx@${conn.connectionId}`);
   }
 
   /** TODO: write doc comment */
@@ -27,6 +32,7 @@ class Dataset {
     sql += this.orderSql;
     sql += this.limitOffsetSql;
 
+    this.logger(sql);
     return await db.selectRows(sql, this.conn);
   }
 
@@ -46,11 +52,17 @@ class Dataset {
       VALUES (${vals.join(', ')})
     `;
 
+    const debug = this.logger.extend('create');
+    debug(sql);
+
     const id = await db.insertWithId(sql, this.conn);
+    debug(`DB returned id ${id}`);
     // FIXME: hardcoded `id` column
     // Also, this.get may fail due to inserting the record
     // that does not match the filters
-    if (id) return await this.get({ id });
+    if (id) record = await this.get({ id });
+
+    debug(`-> ${record}`);
 
     return record;
   }
@@ -63,7 +75,7 @@ class Dataset {
     sql += this.orderSql;
     sql += this.limitOffsetSql;
 
-    return await db.executeAndAffected(sql, this.conn);
+    return await this.executeAndAffected(sql);
   }
 
   /** TODO: write doc comment */
@@ -77,6 +89,7 @@ class Dataset {
 
     if (this.startRow) sql += ` OFFSET ${db.escape(this.startRow)}`;
 
+    this.logger(sql);
     return await db.selectRow(sql, this.conn);
   }
 
@@ -86,6 +99,7 @@ class Dataset {
 
     sql += this.whereSql();
 
+    this.logger.extend('count')(sql);
     return await db.selectValue(sql);
   }
 
@@ -97,6 +111,7 @@ class Dataset {
     sql += this.orderSql;
     sql += this.limitOffsetSql;
 
+    this.logger.extend('pluck')(sql);
     return await db.pluck(sql, this.conn);
   }
 
@@ -108,7 +123,7 @@ class Dataset {
     sql += this.orderSql;
     sql += this.limitOffsetSql;
 
-    return await db.executeAndAffected(sql, this.conn);
+    return await this.executeAndAffected(sql);
   }
 
   /** TODO: write doc comment */
@@ -246,6 +261,15 @@ class Dataset {
     if (isPresent(conditions)) return ` WHERE ${db.conditions(conditions)}`;
 
     return '';
+  }
+
+  /** @private */
+  async executeAndAffected(sql) {
+    this.logger(sql);
+    const res = await db.executeAndAffected(sql, this.conn);
+    this.logger(`-> ${sql}`);
+
+    return res;
   }
 }
 

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -1,3 +1,7 @@
+const logger = require('debug');
+
+const debug = logger('db:migrate');
+
 // FIXME: running migrations requires multiple statements flag being set
 //
 // TODO: destructure used methods from adapter into local consts
@@ -66,6 +70,7 @@ async function loadAvailableMigrations(migrationsPath) {
 
 async function applyMigration(migration) {
   try {
+    debug(`Running ${migration.name}`);
     await migration.runner(migration);
   } catch (err) {
     console.error(migration.name + ':\n\t', err);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "@snooty/utils": "^1.4.0",
+    "debug": "^4.2.0",
     "mysql2": "^2.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "@snooty/utils": "^1.4.0",
-    "debug": "^4.2.0",
+    "debug": "^4.3.0",
     "mysql2": "^2.2.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,13 @@
   resolved "https://registry.yarnpkg.com/@snooty/utils/-/utils-1.4.0.tgz#e9ff727cee09e0ef3869c0fb8a5fb4b62ac73e01"
   integrity sha512-lHqQVLv2xCN/RQ85Wg2xJKnd3rlgW+sWYWMNqoYGOKWClK4a/jF0ewxolYkx2Qnss2eJQtHnSDkmiP3CZ67NuQ==
 
+debug@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
+
 denque@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
@@ -50,6 +57,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 mysql2@^2.2.5:
   version "2.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@snooty/utils/-/utils-1.4.0.tgz#e9ff727cee09e0ef3869c0fb8a5fb4b62ac73e01"
   integrity sha512-lHqQVLv2xCN/RQ85Wg2xJKnd3rlgW+sWYWMNqoYGOKWClK4a/jF0ewxolYkx2Qnss2eJQtHnSDkmiP3CZ67NuQ==
 
-debug@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
-  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+debug@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.0.tgz#efa41cbf14fc9448075367fdaaddf82376da211e"
+  integrity sha512-jjO6JD2rKfiZQnBoRzhRTbXjHLGLfH+UtGkWLc/UXAh/rzZMyjbgn0NcfFpqT8nd1kTtFnDiJcrIFkq4UKeJVg==
   dependencies:
     ms "2.1.2"
 


### PR DESCRIPTION
Debug is provided by [debug](https://www.npmjs.com/package/debug) package

use `DEBUG=db:sql` to dump every query as it goes to database
use `DEBUG=db:dataset:${dataset}` to dump queries generated by `db.dataset()` methods.

A connection id is appended as transaction identifier if queries is executed within a transaction.